### PR TITLE
Edit object-oriented programming table

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Books | Price | Release
 ### Object-Oriented Programming
 Books | Price | Release
 :-- | :--: | :--:
-Object-Oriented Programming | [JavaScript Spessore](https://leanpub.com/javascript-spessore/read) | :free: | -
+[JavaScript Spessore](https://leanpub.com/javascript-spessore/read) | :free: | -
 [The Principles of Object-Oriented JavaScript](http://shop.oreilly.com/product/9781593275402.do) | :moneybag: | February 2014
 
 ### Asynchronous Programming


### PR DESCRIPTION
The markup has extra text 'Object-Oriented Programming'. So, the name of the book 'JavaScript Spessore' was present in the price column while the name filed contained 'Object-Oriented Programming'. Removed the extra text.